### PR TITLE
BLK-8: Feature Matrix and profile API's

### DIFF
--- a/blkshp_os/blkshp_os/api/core_platform.py
+++ b/blkshp_os/blkshp_os/api/core_platform.py
@@ -1,0 +1,34 @@
+"""Core Platform API endpoints."""
+from __future__ import annotations
+
+from typing import Any
+
+import frappe
+from frappe.utils import cint
+
+from blkshp_os.core_platform.services import (
+	get_feature_matrix_for_user,
+	get_user_profile,
+)
+
+
+@frappe.whitelist()
+def get_feature_matrix(refresh: int | str | None = None) -> dict[str, Any]:
+	"""Return the feature matrix for the current tenant user.
+
+	The response is strictly read-only; feature toggles remain managed solely by
+	BLKSHP Operations. Pass ``refresh=1`` to bypass cached plan data.
+	"""
+	force_refresh = bool(cint(refresh)) if refresh is not None else False
+	return get_feature_matrix_for_user(refresh=force_refresh)
+
+
+@frappe.whitelist()
+def get_profile(refresh: int | str | None = None) -> dict[str, Any]:
+	"""Return the authenticated user's profile summary.
+
+	Includes tenant company, department access, subscription snapshot, and
+	permission summary. Pass ``refresh=1`` to bypass cached plan data.
+	"""
+	force_refresh = bool(cint(refresh)) if refresh is not None else False
+	return get_user_profile(refresh=force_refresh)

--- a/blkshp_os/blkshp_os/core_platform/doctype/feature_toggle/feature_toggle.py
+++ b/blkshp_os/blkshp_os/core_platform/doctype/feature_toggle/feature_toggle.py
@@ -7,7 +7,10 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-from blkshp_os.core_platform.services import clear_subscription_context_cache
+from blkshp_os.core_platform.services import (
+	clear_feature_matrix_cache,
+	clear_subscription_context_cache,
+)
 
 _FEATURE_KEY_PATTERN = re.compile(r"^[a-z0-9_.-]+$")
 
@@ -21,9 +24,11 @@ class FeatureToggle(Document):
 
 	def on_update(self) -> None:
 		clear_subscription_context_cache()
+		clear_feature_matrix_cache()
 
 	def on_trash(self) -> None:
 		clear_subscription_context_cache()
+		clear_feature_matrix_cache()
 
 	def _normalize_feature_key(self) -> None:
 		if not self.feature_key:

--- a/blkshp_os/blkshp_os/core_platform/doctype/module_activation/module_activation.py
+++ b/blkshp_os/blkshp_os/core_platform/doctype/module_activation/module_activation.py
@@ -8,7 +8,10 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-from blkshp_os.core_platform.services import clear_subscription_context_cache
+from blkshp_os.core_platform.services import (
+	clear_feature_matrix_cache,
+	clear_subscription_context_cache,
+)
 
 
 class ModuleActivation(Document):
@@ -88,6 +91,8 @@ class ModuleActivation(Document):
 
 	def on_update(self) -> None:
 		clear_subscription_context_cache()
+		clear_feature_matrix_cache()
 
 	def on_trash(self) -> None:
 		clear_subscription_context_cache()
+		clear_feature_matrix_cache()

--- a/blkshp_os/blkshp_os/core_platform/doctype/subscription_plan/subscription_plan.py
+++ b/blkshp_os/blkshp_os/core_platform/doctype/subscription_plan/subscription_plan.py
@@ -8,7 +8,10 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-from blkshp_os.core_platform.services import clear_subscription_context_cache
+from blkshp_os.core_platform.services import (
+	clear_feature_matrix_cache,
+	clear_subscription_context_cache,
+)
 
 
 class SubscriptionPlan(Document):
@@ -53,6 +56,8 @@ class SubscriptionPlan(Document):
 
 	def on_update(self) -> None:
 		clear_subscription_context_cache()
+		clear_feature_matrix_cache()
 
 	def on_trash(self) -> None:
 		clear_subscription_context_cache()
+		clear_feature_matrix_cache()

--- a/blkshp_os/blkshp_os/core_platform/doctype/tenant_branding/tenant_branding.py
+++ b/blkshp_os/blkshp_os/core_platform/doctype/tenant_branding/tenant_branding.py
@@ -8,7 +8,10 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-from blkshp_os.core_platform.services import clear_subscription_context_cache
+from blkshp_os.core_platform.services import (
+	clear_feature_matrix_cache,
+	clear_subscription_context_cache,
+)
 
 
 class TenantBranding(Document):
@@ -40,6 +43,8 @@ class TenantBranding(Document):
 
 	def on_update(self) -> None:
 		clear_subscription_context_cache()
+		clear_feature_matrix_cache()
 
 	def on_trash(self) -> None:
 		clear_subscription_context_cache()
+		clear_feature_matrix_cache()

--- a/blkshp_os/blkshp_os/core_platform/services/__init__.py
+++ b/blkshp_os/blkshp_os/core_platform/services/__init__.py
@@ -1,6 +1,12 @@
 """Core Platform service helpers."""
 from __future__ import annotations
 
+from .feature_matrix import (
+	clear_feature_matrix_cache,
+	get_feature_matrix,
+	get_feature_matrix_for_user,
+	get_user_profile,
+)
 from .subscription_context import (
 	clear_subscription_context_cache,
 	get_subscription_context,
@@ -8,8 +14,12 @@ from .subscription_context import (
 )
 
 __all__ = [
+	"clear_feature_matrix_cache",
 	"clear_subscription_context_cache",
+	"get_feature_matrix",
+	"get_feature_matrix_for_user",
 	"get_subscription_context",
+	"get_user_profile",
 	"resolve_plan_for_company",
 ]
 

--- a/blkshp_os/blkshp_os/core_platform/services/feature_matrix.py
+++ b/blkshp_os/blkshp_os/core_platform/services/feature_matrix.py
@@ -1,0 +1,260 @@
+"""Feature matrix and profile helpers."""
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+import frappe
+from frappe.utils import now
+
+from .subscription_context import (
+	ModuleActivationState,
+	SubscriptionContext,
+	SubscriptionPlanState,
+	get_subscription_context,
+	resolve_plan_for_company,
+)
+from blkshp_os.permissions import roles as role_service
+from blkshp_os.permissions import service as permission_service
+
+
+FEATURE_MATRIX_CACHE_KEY = "blkshp_os:core_platform:feature_matrix"
+_CACHE_PLAN_FALLBACK = "__no_plan__"
+_ADMIN_MESSAGE = "Feature toggles are administered solely by BLKSHP Operations."
+
+
+def _normalize_plan_key(plan_code: str | None) -> str:
+	"""Return the normalized cache key for a plan code."""
+	if not plan_code:
+		return _CACHE_PLAN_FALLBACK
+	return (plan_code or "").strip().lower() or _CACHE_PLAN_FALLBACK
+
+
+def _load_cache() -> dict[str, dict[str, Any]]:
+	"""Load the cached feature matrix map from frappe.cache."""
+	cache = frappe.cache()
+	cached = cache.get_value(FEATURE_MATRIX_CACHE_KEY)
+	return cached or {}
+
+
+def _store_cache(cache_map: Mapping[str, dict[str, Any]]) -> None:
+	"""Persist the provided cache map."""
+	frappe.cache().set_value(FEATURE_MATRIX_CACHE_KEY, dict(cache_map))
+
+
+def clear_feature_matrix_cache() -> None:
+	"""Clear the cached feature matrix payloads."""
+	frappe.cache().delete_value(FEATURE_MATRIX_CACHE_KEY)
+
+
+def _serialize_plan(plan: SubscriptionPlanState | None) -> dict[str, Any] | None:
+	"""Return a serializable representation of the subscription plan."""
+	if not plan:
+		return None
+	return {
+		"name": plan.name,
+		"code": plan.plan_code,
+		"label": plan.plan_name,
+		"is_active": bool(plan.is_active),
+		"is_default": bool(plan.is_default),
+		"billing_frequency": plan.billing_frequency,
+		"billing_currency": plan.billing_currency,
+		"base_price": plan.base_price,
+		"default_feature_overrides": dict(plan.default_feature_overrides),
+	}
+
+
+def _serialize_module(module: ModuleActivationState) -> dict[str, Any]:
+	"""Return a serializable representation of the module activation state."""
+	return {
+		"key": module.key,
+		"label": module.label,
+		"is_enabled": bool(module.is_enabled),
+		"is_required": bool(module.is_required),
+		"depends_on": list(module.depends_on),
+		"feature_overrides": dict(module.feature_overrides),
+	}
+
+
+def _serialize_registry(context: SubscriptionContext) -> dict[str, dict[str, Any]]:
+	"""Return the flattened feature registry metadata."""
+	return {
+		key: {
+			"key": metadata.key,
+			"name": metadata.name,
+			"category": metadata.category,
+			"default_enabled": bool(metadata.default_enabled),
+			"description": metadata.description,
+		}
+		for key, metadata in context.registry.items()
+	}
+
+
+def _build_plan_matrix(
+	context: SubscriptionContext,
+	plan_code: str | None,
+) -> dict[str, Any]:
+	"""Construct the plan-level feature matrix payload."""
+	modules = [_serialize_module(module) for module in context.modules.values()]
+	modules.sort(key=lambda entry: entry["key"])
+
+	enabled_modules = [module["key"] for module in modules if module["is_enabled"]]
+
+	return {
+		"plan_code": context.plan.plan_code if context.plan else plan_code,
+		"plan": _serialize_plan(context.plan),
+		"modules": modules,
+		"enabled_modules": enabled_modules,
+		"feature_states": dict(context.feature_states),
+		"registry": _serialize_registry(context),
+		"administration": {
+			"managed_by": "BLKSHP Operations",
+			"message": _ADMIN_MESSAGE,
+		},
+	}
+
+
+def get_feature_matrix(
+	*, plan_code: str | None = None, company: str | None = None, refresh: bool = False
+) -> dict[str, Any]:
+	"""Return the plan-level feature matrix for the supplied plan/company.
+
+	When refresh is False the serialized payload is cached in frappe.cache()
+	using a normalized plan key. Invalidation is handled via DocType hooks
+	by calling :func:`clear_subscription_context_cache` and
+	:func:`clear_feature_matrix_cache`.
+	"""
+	resolved_plan = plan_code or resolve_plan_for_company(company)
+	cache_key = _normalize_plan_key(resolved_plan)
+	cache_map = {} if refresh else _load_cache()
+
+	if not refresh and cache_key in cache_map:
+		payload = copy.deepcopy(cache_map[cache_key])
+	else:
+		context = get_subscription_context(
+			company=company, plan_code=resolved_plan, use_cache=not refresh
+		)
+		payload = _build_plan_matrix(context, resolved_plan)
+		if not refresh:
+			cache_map[cache_key] = copy.deepcopy(payload)
+			_store_cache(cache_map)
+
+	payload["generated_at"] = now()
+	return payload
+
+
+def _evaluate_module_access(user: str, modules: list[dict[str, Any]], refresh: bool) -> dict[str, bool]:
+	"""Return a mapping of module key to access flag for the user."""
+	access_map: dict[str, bool] = {}
+	for module in modules:
+		key = module["key"]
+		access_map[key] = permission_service.user_has_module_access(user, key, refresh=refresh)
+	return access_map
+
+
+def _evaluate_feature_access(
+	user: str,
+	registry: Mapping[str, Any],
+	refresh: bool,
+) -> dict[str, bool]:
+	"""Return a mapping of feature key to access flag for the user."""
+	access_map: dict[str, bool] = {}
+	for feature_key in registry.keys():
+		access_map[feature_key] = permission_service.user_has_feature(
+			user, feature_key, refresh=refresh
+		)
+	return access_map
+
+
+def get_feature_matrix_for_user(
+	user: str | None = None,
+	*,
+	company: str | None = None,
+	refresh: bool = False,
+) -> dict[str, Any]:
+	"""Return the feature matrix augmented with user-specific access flags."""
+	if not user:
+		user = frappe.session.user
+
+	user_company = company or permission_service.get_user_company(user)
+	matrix = get_feature_matrix(plan_code=None, company=user_company, refresh=refresh)
+
+	result = copy.deepcopy(matrix)
+	module_access = _evaluate_module_access(user, result["modules"], refresh)
+	feature_access = _evaluate_feature_access(user, result["registry"], refresh)
+
+	for module in result["modules"]:
+		module["user_has_access"] = module_access[module["key"]]
+
+	result["user_accessible_modules"] = [
+		key for key, has_access in module_access.items() if has_access
+	]
+	result["user_feature_access"] = feature_access
+	result["user"] = {
+		"id": user,
+		"company": user_company,
+		"roles": frappe.get_roles(user),
+	}
+	return result
+
+
+def _summarize_permissions(user: str) -> dict[str, Any]:
+	"""Return a permissions summary for the provided user."""
+	by_category = role_service.get_permissions_by_category(user)
+	total_permissions = sum(len(entries) for entries in by_category.values())
+	return {
+		"roles": frappe.get_roles(user),
+		"by_category": by_category,
+		"total": total_permissions,
+	}
+
+
+def get_user_profile(
+	user: str | None = None,
+	*,
+	refresh: bool = False,
+) -> dict[str, Any]:
+	"""Return a read-only profile summary for the tenant user."""
+	if not user:
+		user = frappe.session.user
+
+	user_doc = frappe.get_cached_doc("User", user)
+	matrix = get_feature_matrix_for_user(user=user, refresh=refresh)
+	departments = permission_service.get_user_department_permissions(user)
+
+	permissions = _summarize_permissions(user)
+	module_summary = [
+		{
+			"key": module["key"],
+			"label": module["label"],
+			"is_enabled": module["is_enabled"],
+			"user_has_access": module["user_has_access"],
+		}
+		for module in matrix["modules"]
+	]
+
+	return {
+		"user": {
+			"id": user_doc.name,
+			"full_name": user_doc.full_name,
+			"email": user_doc.email,
+			"enabled": bool(user_doc.enabled),
+			"roles": permissions["roles"],
+		},
+		"company": matrix["user"]["company"],
+		"departments": departments,
+		"permissions": {
+			"by_category": permissions["by_category"],
+			"total": permissions["total"],
+		},
+		"subscription": {
+			"plan_code": matrix["plan_code"],
+			"plan": matrix["plan"],
+			"modules": module_summary,
+			"user_feature_access": matrix["user_feature_access"],
+			"administration": matrix["administration"],
+		},
+		"generated_at": matrix["generated_at"],
+	}
+
+

--- a/blkshp_os/blkshp_os/core_platform/tests/test_feature_matrix.py
+++ b/blkshp_os/blkshp_os/core_platform/tests/test_feature_matrix.py
@@ -1,0 +1,248 @@
+"""Tests for feature matrix service and API helpers."""
+from __future__ import annotations
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from blkshp_os.core_platform.services import (
+	clear_feature_matrix_cache,
+	clear_subscription_context_cache,
+	get_feature_matrix,
+	get_feature_matrix_for_user,
+	get_user_profile,
+)
+from blkshp_os.core_platform.services.feature_matrix import FEATURE_MATRIX_CACHE_KEY
+
+
+class TestFeatureMatrix(FrappeTestCase):
+	"""Validate feature matrix aggregation and profile helpers."""
+
+	_is_loaded = False
+
+	@classmethod
+	def setUpClass(cls) -> None:
+		super().setUpClass()
+		if not cls._is_loaded:
+			for module, doctype in [
+				("core_platform", "feature_toggle"),
+				("core_platform", "subscription_plan"),
+				("core_platform", "module_activation"),
+				("core_platform", "tenant_branding"),
+				("departments", "department"),
+				("permissions", "department_permission"),
+			]:
+				frappe.reload_doc(module, "doctype", doctype)
+			cls._is_loaded = True
+
+	def setUp(self) -> None:
+		super().setUp()
+		frappe.db.rollback()
+		clear_subscription_context_cache()
+		clear_feature_matrix_cache()
+
+		self.company = self._create_company("Matrix Test Company", "MTC", "USD")
+		self.department = self._create_department("Matrix Department", "MATRIX", self.company.name)
+		self._create_tenant_branding(self.company.name, "FOUNDATION")
+
+		self._ensure_role("Employee")
+		self._ensure_role("System Manager")
+
+		self.standard_user = self._create_user(
+			"matrix.user@example.com",
+			"Matrix",
+			roles=["Employee"],
+			company=self.company.name,
+			department=self.department.name,
+		)
+		self.operations_user = self._create_user(
+			"ops.user@example.com",
+			"Ops",
+			roles=["System Manager"],
+			company=self.company.name,
+		)
+
+	def test_feature_matrix_includes_modules_and_features(self) -> None:
+		"""Plan metadata, modules, and feature flags are exposed for tenant users."""
+		matrix = get_feature_matrix_for_user(user=self.standard_user)
+
+		self.assertEqual(matrix["plan_code"], "FOUNDATION")
+		self.assertIn("core", matrix["enabled_modules"])
+
+		module_map = {module["key"]: module for module in matrix["modules"]}
+		self.assertTrue(module_map["core"]["user_has_access"])
+		self.assertIn("core.workspace.access", matrix["user_feature_access"])
+		self.assertTrue(matrix["user_feature_access"]["core.workspace.access"])
+
+	def test_feature_matrix_cache_cleared(self) -> None:
+		"""Plan-level cache persists and can be cleared explicitly."""
+		get_feature_matrix(plan_code="FOUNDATION")
+		cached = frappe.cache().get_value(FEATURE_MATRIX_CACHE_KEY)
+		self.assertIsInstance(cached, dict)
+		self.assertIn("foundation", cached)
+
+		clear_feature_matrix_cache()
+		self.assertIsNone(frappe.cache().get_value(FEATURE_MATRIX_CACHE_KEY))
+
+	def test_disabled_module_blocks_user_but_not_operations(self) -> None:
+		"""Disabled modules remain inaccessible to standard users but bypass roles still see them."""
+		module_name = frappe.get_value(
+			"Module Activation",
+			{"plan": "FOUNDATION", "module_key": "inventory"},
+			"name",
+		)
+		self.assertIsNotNone(module_name)
+
+		module_doc = frappe.get_doc("Module Activation", module_name)
+		original_state = int(module_doc.is_enabled)
+
+		try:
+			module_doc.is_enabled = 0
+			module_doc.save(ignore_permissions=True)
+			clear_subscription_context_cache()
+			clear_feature_matrix_cache()
+
+			standard_matrix = get_feature_matrix_for_user(user=self.standard_user, refresh=True)
+			operations_matrix = get_feature_matrix_for_user(user=self.operations_user, refresh=True)
+
+			standard_inventory = next(module for module in standard_matrix["modules"] if module["key"] == "inventory")
+			operations_inventory = next(module for module in operations_matrix["modules"] if module["key"] == "inventory")
+
+			self.assertFalse(standard_inventory["is_enabled"])
+			self.assertFalse(standard_inventory["user_has_access"])
+			self.assertTrue(operations_inventory["user_has_access"])
+		finally:
+			module_doc.is_enabled = original_state
+			module_doc.save(ignore_permissions=True)
+			clear_subscription_context_cache()
+			clear_feature_matrix_cache()
+
+	def test_inactive_plan_flag_reflected(self) -> None:
+		"""Inactive plans propagate their status in the matrix payload."""
+		plan_doc = frappe.get_doc("Subscription Plan", "FOUNDATION")
+		original_state = int(plan_doc.is_active)
+
+		try:
+			plan_doc.is_active = 0
+			plan_doc.save(ignore_permissions=True)
+			clear_subscription_context_cache()
+			clear_feature_matrix_cache()
+
+			matrix = get_feature_matrix_for_user(user=self.standard_user, refresh=True)
+			self.assertIsNotNone(matrix["plan"])
+			self.assertFalse(matrix["plan"]["is_active"])
+		finally:
+			plan_doc.is_active = original_state
+			plan_doc.save(ignore_permissions=True)
+			clear_subscription_context_cache()
+			clear_feature_matrix_cache()
+
+	def test_user_profile_summary(self) -> None:
+		"""Profile endpoint returns company and permission details."""
+		profile = get_user_profile(user=self.standard_user)
+
+		self.assertEqual(profile["company"], self.company.name)
+		self.assertTrue(profile["departments"])
+		self.assertIn("plan_code", profile["subscription"])
+		self.assertEqual(profile["subscription"]["plan_code"], "FOUNDATION")
+		self.assertGreaterEqual(profile["permissions"]["total"], 0)
+		self.assertIn("modules", profile["subscription"])
+		module_keys = {module["key"] for module in profile["subscription"]["modules"]}
+		self.assertIn("core", module_keys)
+
+	# Helpers -----------------------------------------------------------------
+
+	def _create_company(self, company_name: str, abbr: str, default_currency: str):
+		existing = frappe.db.exists("Company", company_name)
+		if existing:
+			return frappe.get_doc("Company", existing)
+		company = frappe.get_doc(
+			{
+				"doctype": "Company",
+				"company_name": company_name,
+				"abbr": abbr,
+				"default_currency": default_currency,
+			}
+		)
+		return company.insert(ignore_permissions=True)
+
+	def _create_department(self, department_name: str, department_code: str, company: str):
+		existing = frappe.db.exists(
+			"Department",
+			{"department_code": department_code, "company": company},
+		)
+		if existing:
+			return frappe.get_doc("Department", existing)
+		department = frappe.get_doc(
+			{
+				"doctype": "Department",
+				"department_name": department_name,
+				"department_code": department_code,
+				"department_type": "Other",
+				"company": company,
+				"is_active": 1,
+			}
+		)
+		return department.insert(ignore_permissions=True)
+
+	def _create_tenant_branding(self, company: str, plan: str) -> None:
+		existing = frappe.db.exists("Tenant Branding", company)
+		if existing:
+			branding = frappe.get_doc("Tenant Branding", existing)
+			branding.plan = plan
+			branding.save(ignore_permissions=True)
+			return
+		branding = frappe.get_doc(
+			{
+				"doctype": "Tenant Branding",
+				"company": company,
+				"plan": plan,
+				"theme_name": "Default",
+			}
+		)
+		branding.insert(ignore_permissions=True)
+
+	def _ensure_role(self, role_name: str) -> None:
+		if frappe.db.exists("Role", role_name):
+			return
+		role = frappe.get_doc({"doctype": "Role", "role_name": role_name})
+		role.insert(ignore_permissions=True)
+
+	def _create_user(
+		self,
+		email: str,
+		first_name: str,
+		*,
+		roles: list[str],
+		company: str | None = None,
+		department: str | None = None,
+	) -> str:
+		existing = frappe.db.exists("User", email)
+		if existing:
+			return existing
+
+		user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": first_name,
+				"send_welcome_email": 0,
+				"time_zone": "UTC",
+			}
+		)
+		for role in roles:
+			user.append("roles", {"role": role})
+		if company:
+			user.company = company
+		if department:
+			user.append(
+				"department_permissions",
+				{"department": department, "can_read": 1, "can_write": 0},
+			)
+		user.insert(ignore_permissions=True)
+
+		if department:
+			user_doc = frappe.get_doc("User", email)
+			user_doc.company = company
+			user_doc.save(ignore_permissions=True)
+
+		return email

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -18,6 +18,140 @@ All API endpoints require authentication. Use Frappe's standard authentication m
 
 ---
 
+## Core Platform API
+
+### Get Feature Matrix
+
+Retrieve subscription plan metadata, module availability, and feature toggles for the authenticated tenant user. Feature administration remains a BLKSHP Operations responsibility and the response is read-only.
+
+**Endpoint:** `/api/method/blkshp_os.api.core_platform.get_feature_matrix`
+
+**Method:** `GET` or `POST`
+
+**Parameters:**
+- `refresh` (int, optional): When set to `1`, bypasses cached plan data before building the matrix. Defaults to `0` (use cached data when available).
+
+**Response:**
+```json
+{
+  "plan_code": "FOUNDATION",
+  "plan": {
+    "code": "FOUNDATION",
+    "label": "Foundation Plan",
+    "is_active": true,
+    "is_default": true,
+    "billing_currency": "USD"
+  },
+  "modules": [
+    {
+      "key": "core",
+      "label": "Core",
+      "is_enabled": true,
+      "is_required": true,
+      "depends_on": [],
+      "feature_overrides": {},
+      "user_has_access": true
+    }
+  ],
+  "enabled_modules": ["core", "inventory"],
+  "user_accessible_modules": ["core", "inventory"],
+  "feature_states": {
+    "core.workspace.access": true
+  },
+  "user_feature_access": {
+    "core.workspace.access": true
+  },
+  "administration": {
+    "managed_by": "BLKSHP Operations",
+    "message": "Feature toggles are administered solely by BLKSHP Operations."
+  },
+  "generated_at": "2025-11-11 12:34:56.000000",
+  "user": {
+    "id": "matrix.user@example.com",
+    "company": "Matrix Test Company",
+    "roles": ["Employee"]
+  }
+}
+```
+
+**Example:**
+```bash
+curl -X GET https://your-site.com/api/method/blkshp_os.api.core_platform.get_feature_matrix \
+  -H "Authorization: token api_key:api_secret"
+```
+
+---
+
+### Get Profile
+
+Return a read-only profile summary for the current user, including company assignment, department permissions, subscription snapshot, and permission catalog.
+
+**Endpoint:** `/api/method/blkshp_os.api.core_platform.get_profile`
+
+**Method:** `GET` or `POST`
+
+**Parameters:**
+- `refresh` (int, optional): When set to `1`, bypasses cached plan data prior to assembling the profile. Defaults to `0`.
+
+**Response:**
+```json
+{
+  "user": {
+    "id": "matrix.user@example.com",
+    "full_name": "Matrix User",
+    "email": "matrix.user@example.com",
+    "enabled": true,
+    "roles": ["Employee"]
+  },
+  "company": "Matrix Test Company",
+  "departments": [
+    {
+      "department": "MATRIX",
+      "can_read": 1,
+      "can_write": 0
+    }
+  ],
+  "permissions": {
+    "by_category": {
+      "inventory": [{"permission_code": "inventory.audit.run"}],
+      "system": []
+    },
+    "total": 12
+  },
+  "subscription": {
+    "plan_code": "FOUNDATION",
+    "plan": {
+      "code": "FOUNDATION",
+      "label": "Foundation Plan"
+    },
+    "modules": [
+      {
+        "key": "core",
+        "label": "Core",
+        "is_enabled": true,
+        "user_has_access": true
+      }
+    ],
+    "user_feature_access": {
+      "core.workspace.access": true
+    },
+    "administration": {
+      "managed_by": "BLKSHP Operations",
+      "message": "Feature toggles are administered solely by BLKSHP Operations."
+    }
+  },
+  "generated_at": "2025-11-11 12:34:56.000000"
+}
+```
+
+**Example:**
+```bash
+curl -X GET https://your-site.com/api/method/blkshp_os.api.core_platform.get_profile \
+  -H "Authorization: token api_key:api_secret"
+```
+
+---
+
 ## Department API
 
 ### Get Accessible Departments


### PR DESCRIPTION
## Summary
- add feature matrix service with cache + user/profile helpers
- expose new API endpoints and document them
- add tests covering caching, module gating, inactive plan edge cases

## Testing
- not run (bench tests unavailable in CI sandbox)"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce cached feature matrix service with user access evaluation, expose `get_feature_matrix` and `get_profile` endpoints, add cache invalidation hooks, and document/tests for coverage.
> 
> - **Core Platform Service**:
>   - `core_platform/services/feature_matrix.py`: Add feature matrix builder with plan/module/feature serialization, user access evaluation, and frappe.cache-backed storage (`FEATURE_MATRIX_CACHE_KEY`), plus `clear_feature_matrix_cache`, `get_feature_matrix`, `get_feature_matrix_for_user`, and `get_user_profile`.
>   - `core_platform/services/__init__.py`: Export new service functions.
> - **DocTypes (cache invalidation)**:
>   - `feature_toggle.py`, `module_activation.py`, `subscription_plan.py`, `tenant_branding.py`: Call `clear_feature_matrix_cache()` alongside `clear_subscription_context_cache()` on update/trash.
> - **API Endpoints**:
>   - `api/core_platform.py`: Add whitelisted `get_feature_matrix(refresh)` and `get_profile(refresh)`.
> - **Docs**:
>   - `docs/API-REFERENCE.md`: Document Core Platform endpoints with parameters and example responses.
> - **Tests**:
>   - `core_platform/tests/test_feature_matrix.py`: Cover caching behavior, module gating vs. roles, inactive plan reflection, and profile payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d996a4a2f90798f2e5d6f8e8c32aca42e7469c81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->